### PR TITLE
#1 Exists properly prepends FS's working directory path.

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -101,7 +101,7 @@ func (d DiskFS) Stat(filePath string) (FileInfo, error) {
 
 // Exists returns true when the file/directory already exits in the file system.
 func (d DiskFS) Exists(filePath string) bool {
-	_, err := os.Stat(filePath)
+	_, err := os.Stat(path.Join(d.basePath, filePath))
 	return err == nil
 }
 

--- a/disk_test.go
+++ b/disk_test.go
@@ -83,10 +83,20 @@ func (s *DiskTestSuite) TestExists() {
 	s.Require().True(fs.Exists("."), "Current directory should exist")
 	s.Require().True(fs.Exists(".."), "Parent directory should exist")
 
-	s.Require().True(fs.Exists("testdata"), "Real directory should exist")
-	s.Require().True(fs.Exists("testdata/hello.txt"), "Real file should exist")
-	s.Require().True(fs.Exists("testdata/inner1/inner2/../foo.txt"), "Real file should exist")
+	s.Require().False(fs.Exists("testdata"), "Already in 'testdata' directory, so checking Exists('testdata') should be false.")
+
+	// Real files/dirs should exist regardless of nesting
+	s.Require().True(fs.Exists("hello.txt"), "Real file should exist")
+	s.Require().True(fs.Exists("inner1"), "Real directory should exist")
+	s.Require().True(fs.Exists("inner1/inner2/../foo.txt"), "Real file should exist when specifying relative path")
+	s.Require().True(fs.Exists("inner1/inner2/.."), "Real dir should exist when specifying relative path")
+
 	s.Require().False(fs.Exists("asldkfj"), "Non-existing entry should be false for Exists()")
+	s.Require().False(fs.Exists("inner1/alskdjfalkdsfj.txt"), "Non-existing entry should be false for Exists() even when parent directory exists")
+
+	// Bug fix where we weren't prepending the base directory to the path you provide.
+	s.Require().True(fs.ChangeDirectory("inner1").Exists("inner2/../foo.txt"), "Real file should exist even after cd")
+	s.Require().False(fs.ChangeDirectory("inner1").Exists("inner2/../nope.txt"), "Non-existing file should not exist even after cd")
 }
 
 func (s *DiskTestSuite) TestList_noFilters() {


### PR DESCRIPTION
As suspected, I was not prepending the current working directory of the FS to the path the user provided, so all paths were relative to the execution directory rather than the FS's working directory.

```
// Before this would look for "./foo.txt" as expected
fs := filestore.Disk(".")
fs.Exists("foo.txt")

// Before, this STILL looked for "./foo.txt" instead of "./bar/foo.txt"
fs = fs.ChangeDirectory("bar")
fs.Exists("foo.txt")
```

I added a few additional test cases to the suite to try and catch more edge cases of this as well.